### PR TITLE
blog.md: Fix Markdown heading

### DIFF
--- a/blog.md
+++ b/blog.md
@@ -1,4 +1,4 @@
-#Making WebAssembly Components with Zig
+# Making WebAssembly Components with Zig
 
 The component model is one of the more recent developments in WebAssembly, and is interesting for several reasons.  In core WebAssembly, there are concepts of both guests and hosts.  A guest is code that is compiled to Webassembly, and a host executes the functionality that the WebAssembly module exposes. In this post, our guest will be implemented in zig, and our host will be javascript.  When using components instead of core wasm modules, we get much added convenience when linking multiple modules to each other, as well as when passing functions back and forth between guest and host code.  In this post, we'll cover how to create a WebAssembly component using `wasm-tools`, which is a utility that the developers of wasmtime have made to help their development.  Most developers probably won't interact with this toolchain directly, but will use other interfaces that use this functionality, as more languages add support for the component model.  
 


### PR DESCRIPTION
Not sure about the seemingly ephemeral diff on the last line. I only inserted the single space symbol on the first line.